### PR TITLE
Update README for basic report template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
-# U.S. Web Design Standards template for Federalist
-This is a Federalist site template that incorporates the [U.S. Web Design
-Standards] [Jekyll theme].
+# Basic report template for Federalist
 
-View the [theme documentation] for more info on available [layouts] and
-[customization] options.
+This is a [Federalist] site template that incorporates the [U.S. Web Design
+System][uswds] [Jekyll theme].
 
-[U.S. Web Design Standards]: https://standards.usa.gov
+
+## Contributing
+
+See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
+
+
+## Public domain
+
+This project is in the worldwide [public domain](LICENSE.md). As stated in
+[CONTRIBUTING](CONTRIBUTING.md):
+
+> This project is in the public domain within the United States, and copyright
+> and related rights in the work worldwide are waived through the [CC0 1.0
+> Universal public domain
+> dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+>
+> All contributions to this project will be released under the CC0
+> dedication. By submitting a pull request, you are agreeing to comply with
+> this waiver of copyright interest.
+
+
+[basic report template docs]: https://github.com/18F/federalist-uswds-template/wiki/Basic-report-template
+[Federalist]: https://federalist.18f.gov/sites
 [Jekyll theme]: https://jekyllrb.com/docs/themes/
-[theme documentation]: https://github.com/18F/jekyll-uswds/#readme
-[layouts]: https://github.com/18F/jekyll-uswds/#layouts
-[customization]: https://github.com/18F/jekyll-uswds/#customization
+[uswds]: https://designsystem.digital.gov/
+
+---
+_Not sure how to use this template? Check out the [basic report template docs]._

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in
 > this waiver of copyright interest.
 
 
-[basic report template docs]: https://github.com/18F/federalist-uswds-template/wiki/Basic-report-template
+[basic report template docs]: https://federalist-docs.18f.gov/pages/using-federalist/templates/basic-report/
 [Federalist]: https://federalist.18f.gov/sites
 [Jekyll theme]: https://jekyllrb.com/docs/themes/
 [uswds]: https://designsystem.digital.gov/


### PR DESCRIPTION
Part of https://github.com/18F/federalist/issues/1747

I've been wrestling with how exactly to present this information. The template itself is what we're handing over to the customer, so the README shouldn't really contain too much documentation. After all, it's going to become the customer's README. So I opted to put the documentation in the [wiki](https://github.com/18F/federalist-uswds-template/wiki). It's a little awkward, because uswds-jekyll has a lot of customization options and a lot of the documentation lives there. 

However, for a customer using the basic report template, they probably want to know how to add their report to their website. This is surprisingly not obvious, so that's the kind of documentation I chose to include on the wiki.

Anyway, really just looking for feedback here. What do folks think about organizing the documentation this way?